### PR TITLE
Add support for linking created issues to original GitHub issues

### DIFF
--- a/.github/workflows/assistent.yml
+++ b/.github/workflows/assistent.yml
@@ -45,5 +45,5 @@ jobs:
         run: uv sync --locked
 
       - name: Run the Learning Assistent
-        run: uv run run_graph.py --issue-title "${{ github.event.issue.title }}" --issue-body "${{ github.event.issue.body }}" \
+        run: uv run run_graph.py --issue-id "${{ github.event.issue.number }}" --issue-title "${{ github.event.issue.title }}" --issue-body "${{ github.event.issue.body }}" \
           --create-github-issues --github-owner "${{ github.event.organization }}" --github-repo "${{ github.event.repository}}" --no-dry-run

--- a/run_graph.py
+++ b/run_graph.py
@@ -13,6 +13,13 @@ async def main():
     parser.add_argument("--issue-title", type=str, required=True)
     parser.add_argument("--issue-body", type=str, required=True)
     parser.add_argument(
+        "--issue-id",
+        type=int,
+        required=False,
+        default=None,
+        help="Optional original GitHub issue number to link the created issues back to",
+    )
+    parser.add_argument(
         "--style-guide",
         type=str,
         required=False,
@@ -43,6 +50,7 @@ async def main():
         md, gh = await run_graph_with_github(
             issue_title=args.issue_title,
             issue_body=args.issue_body,
+			original_issue_number=args.issue_id,
             style_guide=args.style_guide,
             github_owner=args.github_owner,
             github_repo=args.github_repo,
@@ -52,6 +60,7 @@ async def main():
         md = await run_graph(
             issue_title=args.issue_title,
             issue_body=args.issue_body,
+			original_issue_number=args.issue_id,
             style_guide=args.style_guide,
         )
 


### PR DESCRIPTION
- Updated the workflow to pass the original issue number when running the assistant.
- Enhanced the GitHub client with methods to create comments and update issue bodies.
- Modified the graph and run_graph scripts to accept an optional original issue ID for better traceability.